### PR TITLE
* add --tail option to logs

### DIFF
--- a/ms/core.py
+++ b/ms/core.py
@@ -49,7 +49,7 @@ def run(args):
 
 def logs(args):
     """Display logs for one or more running containers"""
-    utils.show_logs_for_running_containers(args.services, args.f)
+    utils.show_logs_for_running_containers(args.services, args.f, args.t)
 
 
 def kill(args):
@@ -90,6 +90,8 @@ def add_commands(subparsers):
 
     logs_parser = subparsers.add_parser('logs')
     logs_parser.add_argument('-f', action='store_true', help='Continuously tail the running container log')
+    logs_parser.add_argument('-t', help='Number of lines to show from the end of the logs for each container. (e.g. '
+                                        '-t 400)')
     logs_parser.add_argument('services', nargs='*')
     logs_parser.set_defaults(func=logs)
 

--- a/ms/utils.py
+++ b/ms/utils.py
@@ -284,16 +284,23 @@ def kill_all_docker_containers():
         subprocess.call(['docker', 'kill'] + running_container_ids)
 
 
-def show_logs_for_running_containers(services, tail):
+def show_logs_for_running_containers(services, tail, tail_count):
     """Run the docker-compose logs command for one or more running containers"""
     if not check_for_docker_compose_file():
         log.info('No running containers found')
         sys.exit(1)
 
     try:
+        args = ['logs']
+
         if tail:
-            run_docker_compose_command(['logs', '-f'] + services)
-        else:
-            run_docker_compose_command(['logs'] + services)
+            args.append('-f')
+
+        if tail_count:
+            args.append(f'--tail={tail_count}')
+
+        final_result = args + services
+
+        run_docker_compose_command(final_result)
     except KeyboardInterrupt:
         sys.exit(0)


### PR DESCRIPTION
Useful since Docker keeps a HUGE history of your logs, and sometimes you want to tail with just a bit of context from previous runs.

```ms logs my-worker -f -t 10```